### PR TITLE
Add `autoexportFormats` conf option

### DIFF
--- a/chapters.conf
+++ b/chapters.conf
@@ -13,6 +13,11 @@
 # when closing a media file, automatically write the chapter file to disk
 # autosave=no
 
+# comma-separated (no spaces) list of formats to export to (independent from autosave)
+# allowed formats are: list.txt (no timestamps), txt (with timestamps), xml (MKV compatible)
+# Note: These export formats cannot be loaded by MPV. If you plan on editing these later, enable autosave as well
+# autoexportFormats=
+
 # if 'no', chapter files will be stored in the same directory as the corresponding
 # media files, if 'yes' they will be stored in a configured global directory
 # global_chapters=no

--- a/chapters.lua
+++ b/chapters.lua
@@ -43,6 +43,7 @@ local options = {
     pause_on_input = false,
     autoload = true,
     autosave = false,
+    autoexportFormats = '',
     -- save all chapter files in a single global directory or next to the playback file
     global_chapters = false,
     chapters_dir = mp.command_native({"expand-path", "~~home/chapters"}),
@@ -793,6 +794,26 @@ end
 
 if options.autosave then
     mp.add_hook("on_unload", 10, function () write("ffmetadata", false, true) end)
+end
+
+if not (options.autoexportFormats == '') then
+    local formats = {}
+    for format in string.gmatch(options.autoexportFormats, '[^,]+') do
+        if (format == 'list.txt'
+            or format == 'txt'
+            or format == 'xml') then
+                table.insert(formats,format)
+        end
+    end
+
+    if #formats == 0 then
+        msg.warn('autoexportFormats was set, but no valid formats were found')
+        return
+    end
+
+    for _,format in pairs(formats) do
+        mp.add_hook("on_unload", 10, function () write(format, false, false) end)
+    end
 end
 
 mp.add_hook("on_unload", 10, function () input.terminate() end)


### PR DESCRIPTION
* Fixes #28

I'm not sure if the check/fallback is required or if we should just rely on users to not enter nonsense into the conf-file.

---

~~I would also like to save the XML with an actual `.xml` file-extension but I noticed that is more elaborate because of the auto-load depending on the current filename.~~
done

---

On a tangential note, why is `false` passed for the `store` argument here:
https://github.com/mar04/chapters_for_mpv/blob/0f0f8f0275253f6f014e83deb3e799ce0b6dd6bb/chapters.lua#L795

Unless I'm misreading what this does, this means it's not respecting the conf file setting for global storage, correct? I looked at the commits for this line briefly but I couldn't find why it was done this way.